### PR TITLE
Initialize `accessEntry` in notifyAccess callback correctly.

### DIFF
--- a/src/Acc.js
+++ b/src/Acc.js
@@ -67,6 +67,8 @@ function makeAccessController(rerun) {
   // It records the access in the `accesses` map.
   function notifyAccess({object, name}) {
     
+    var accessEntry = accesses.get(object);
+    
     // Create an observer for changes in properties accessed during execution of this function.
     function makeAccessedObserver() {
       return Observer(object, function(changes) {


### PR DESCRIPTION
`accessEntry` is the entry for this object that is stored in the accesses map. This variable was not initialized in the callbacks that upwardables invoke when their properties are accessed. This commit initializes the variable correctly.
